### PR TITLE
Fix: Workaround for gcc/clang constructor ambiguity problem

### DIFF
--- a/cartographer/sensor/compressed_point_cloud_test.cc
+++ b/cartographer/sensor/compressed_point_cloud_test.cc
@@ -48,7 +48,7 @@ MATCHER_P(ApproximatelyEquals, expected,
 // Helper function to test the mapping of a single point. Includes test for
 // recompressing the same point again.
 void TestPoint(const Eigen::Vector3f& p) {
-  CompressedPointCloud compressed({{p}});
+  CompressedPointCloud compressed({{p}, {}});
   EXPECT_EQ(1, compressed.size());
   EXPECT_THAT(*compressed.begin(), ApproximatelyEquals(p));
   CompressedPointCloud recompressed({*compressed.begin()});


### PR DESCRIPTION
fix: gcc fails with ambiguous constructor selection, where clang doesn't. Couldn't root-cause the issue, but this is a work around

